### PR TITLE
modified graphics display event hooks

### DIFF
--- a/BLTouch/bltouch.c
+++ b/BLTouch/bltouch.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_IO_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/Examples/extended_grbl_cmd.c
+++ b/Examples/extended_grbl_cmd.c
@@ -25,7 +25,7 @@
 /**
  * @brief	Check if your current module is up to date with the current core version of module 
  */
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/Examples/extended_mcode.c
+++ b/Examples/extended_mcode.c
@@ -26,7 +26,7 @@
 /**
  * @brief	Check if your current module is up to date with the current core version of module
  */
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/Examples/extended_setting.c
+++ b/Examples/extended_setting.c
@@ -14,7 +14,7 @@
 
 #ifdef ENABLE_SETTINGS_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/Examples/extended_task.c
+++ b/Examples/extended_task.c
@@ -16,7 +16,7 @@
 /**
  * @brief	Check if your current module is up to date with the current core version of module 
  */
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/G33/parser_g33.c
+++ b/G33/parser_g33.c
@@ -23,7 +23,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/G5/parser_g5.c
+++ b/G5/parser_g5.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/G7-G8/parser_g7_g8.c
+++ b/G7-G8/parser_g7_g8.c
@@ -23,7 +23,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/I2C_LCD/i2c_lcd.c
+++ b/I2C_LCD/i2c_lcd.c
@@ -26,7 +26,7 @@
 
 #ifdef ENABLE_MAIN_LOOP_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/M17-M18/parser_m17_m18.c
+++ b/M17-M18/parser_m17_m18.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/M42/parser_m42.c
+++ b/M42/parser_m42.c
@@ -23,7 +23,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/M62-M65/parser_m62_m65.c
+++ b/M62-M65/parser_m62_m65.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/M67-M68/parser_m67_m68.c
+++ b/M67-M68/parser_m67_m68.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/M80-M81/parser_m80_m81.c
+++ b/M80-M81/parser_m80_m81.c
@@ -22,7 +22,7 @@
 
 #ifdef ENABLE_PARSER_MODULES
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/Smoothie_clustering/smoothie_clustering.c
+++ b/Smoothie_clustering/smoothie_clustering.c
@@ -21,7 +21,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 

--- a/graphic_display/CHANGELOG.md
+++ b/graphic_display/CHANGELOG.md
@@ -5,7 +5,7 @@ This module adds graphic display support for µCNC.
 ## Changelog
 
 ### 2023-10-20
-- modified event hooks used to prevent loop inception that caused some menus to become irresponsive
+- modified event hooks used to prevent loop inception that caused some menus to become irresponsive (#39)
 
 ### 2023-10-11
 - integration of multistream

--- a/graphic_display/CHANGELOG.md
+++ b/graphic_display/CHANGELOG.md
@@ -4,6 +4,9 @@ This module adds graphic display support for µCNC.
 
 ## Changelog
 
+### 2023-10-20
+- modified event hooks used to prevent loop inception that caused some menus to become irresponsive
+
 ### 2023-10-11
 - integration of multistream
 

--- a/graphic_display/graphic_display.c
+++ b/graphic_display/graphic_display.c
@@ -25,7 +25,7 @@
 #include <math.h>
 #include "../system_menu.h"
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10801 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 
@@ -102,10 +102,7 @@ SOFTSPI(graphic_spi, 100000UL, 0, GRAPHIC_DISPLAY_SPI_DATA, GRAPHIC_DISPLAY_SPI_
 
 uint8_t u8x8_byte_ucnc_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 	uint8_t *data;
 	switch (msg)
@@ -117,10 +114,7 @@ uint8_t u8x8_byte_ucnc_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
 			softspi_xmit(graphic_port, (uint8_t)*data);
 			data++;
 			arg_int--;
-			if (!cnc_get_exec_state(EXEC_ALARM))
-			{
-				cnc_dotasks();
-			}
+			cnc_dotasks();
 		}
 		break;
 	case U8X8_MSG_BYTE_INIT:
@@ -195,10 +189,7 @@ uint8_t u8x8_byte_ucnc_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
 
 uint8_t u8x8_gpio_and_delay_ucnc(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 	switch (msg)
 	{
@@ -382,7 +373,51 @@ uint8_t u8x8_gpio_and_delay_ucnc(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
 static int8_t graphic_display_rotary_encoder_counter;
 static int8_t graphic_display_rotary_encoder_pressed;
 
-void graphic_display_rotary_encoder_control_sample()
+// reads inputs and returns a mask with a pin state transition
+uint8_t graphic_display_rotary_encoder_control(void)
+{
+	if (graphic_display_rotary_encoder_pressed != 0)
+	{
+		graphic_display_rotary_encoder_pressed = 0;
+		return GRAPHIC_DISPLAY_SELECT;
+	}
+
+	if (graphic_display_rotary_encoder_counter > 0)
+	{
+		graphic_display_rotary_encoder_counter = 0;
+		return GRAPHIC_DISPLAY_NEXT;
+	}
+
+	if (graphic_display_rotary_encoder_counter < 0)
+	{
+		graphic_display_rotary_encoder_counter = 0;
+		return GRAPHIC_DISPLAY_PREV;
+	}
+
+	return 0;
+}
+
+// static bool graphic_display_current_menu_active;
+#ifdef ENABLE_MAIN_LOOP_MODULES
+bool graphic_display_start(void *args)
+{
+	// clear
+	system_menu_render_startup();
+
+	return false;
+}
+CREATE_EVENT_LISTENER(cnc_reset, graphic_display_start);
+
+bool graphic_display_alarm(void *args)
+{
+	// renders the alarm
+	system_menu_render();
+
+	return EVENT_CONTINUE;
+}
+
+
+bool graphic_display_rotary_encoder_control_sample(void *args)
 {
 	static uint8_t last_pin_state = 0;
 	static uint8_t last_rot_transition = 0;
@@ -488,88 +523,50 @@ void graphic_display_rotary_encoder_control_sample()
 			}
 		}
 	}
+
+	return EVENT_CONTINUE;
 }
 
-// reads inputs and returns a mask with a pin state transition
-uint8_t graphic_display_rotary_encoder_control(void)
-{
-	if (graphic_display_rotary_encoder_pressed != 0)
-	{
-		graphic_display_rotary_encoder_pressed = 0;
-		return GRAPHIC_DISPLAY_SELECT;
-	}
-
-	if (graphic_display_rotary_encoder_counter > 0)
-	{
-		graphic_display_rotary_encoder_counter = 0;
-		return GRAPHIC_DISPLAY_NEXT;
-	}
-
-	if (graphic_display_rotary_encoder_counter < 0)
-	{
-		graphic_display_rotary_encoder_counter = 0;
-		return GRAPHIC_DISPLAY_PREV;
-	}
-
-	return 0;
-}
-
-// static bool graphic_display_current_menu_active;
-#ifdef ENABLE_MAIN_LOOP_MODULES
-bool graphic_display_start(void *args)
-{
-	// clear
-	system_menu_render_startup();
-
-	return false;
-}
-CREATE_EVENT_LISTENER(cnc_reset, graphic_display_start);
+CREATE_EVENT_LISTENER(cnc_io_dotasks, graphic_display_rotary_encoder_control_sample);
 
 bool graphic_display_update(void *args)
 {
 	static bool running = false;
 
-	graphic_display_rotary_encoder_control_sample();
-
 	if (!running)
 	{
 		running = true;
+		uint8_t action = SYSTEM_MENU_ACTION_NONE;
 		switch (graphic_display_rotary_encoder_control())
 		{
-		case 0:
-			// no action needed to go idle
-			system_menu_action(SYSTEM_MENU_ACTION_NONE);
-			break;
 		case GRAPHIC_DISPLAY_SELECT:
-			system_menu_action(SYSTEM_MENU_ACTION_SELECT);
+			action = SYSTEM_MENU_ACTION_SELECT;
 			// prevent double click
 			graphic_display_rotary_encoder_pressed = 0;
 			break;
 		case GRAPHIC_DISPLAY_NEXT:
-			system_menu_action(SYSTEM_MENU_ACTION_NEXT);
+			action = SYSTEM_MENU_ACTION_NEXT;
 			break;
 		case GRAPHIC_DISPLAY_PREV:
-			system_menu_action(SYSTEM_MENU_ACTION_PREV);
+			action = SYSTEM_MENU_ACTION_PREV;
 			break;
 		}
 
-		if (!cnc_get_exec_state(EXEC_ALARM))
-		{
-			cnc_dotasks();
-		}
+		system_menu_action(action);
+
+		cnc_dotasks();
 		// render menu
 		system_menu_render();
-		if (!cnc_get_exec_state(EXEC_ALARM))
-		{
-			cnc_dotasks();
-		}
+		cnc_dotasks();
+
 		running = false;
 	}
 
-	return false;
+	return EVENT_CONTINUE;
 }
 
-CREATE_EVENT_LISTENER(cnc_io_dotasks, graphic_display_update);
+CREATE_EVENT_LISTENER(cnc_dotasks, graphic_display_update);
+CREATE_EVENT_LISTENER(cnc_alarm, graphic_display_update);
 #endif
 
 #ifdef DECL_SERIAL_STREAM
@@ -603,11 +600,12 @@ uint8_t system_menu_send_cmd(const char *__s)
 
 	uint8_t len = strlen(__s);
 	uint8_t w;
-	
-	if(BUFFER_WRITE_AVAILABLE(graphic_stream_buffer)<len){
+
+	if (BUFFER_WRITE_AVAILABLE(graphic_stream_buffer) < len)
+	{
 		return STATUS_STREAM_FAILED;
 	}
-	
+
 	BUFFER_WRITE(graphic_stream_buffer, __s, len, w);
 
 	return STATUS_OK;
@@ -646,7 +644,9 @@ DECL_MODULE(graphic_display)
 	system_menu_init();
 #ifdef ENABLE_MAIN_LOOP_MODULES
 	ADD_EVENT_LISTENER(cnc_reset, graphic_display_start);
-	ADD_EVENT_LISTENER(cnc_io_dotasks, graphic_display_update);
+	ADD_EVENT_LISTENER(cnc_alarm, graphic_display_update);
+	ADD_EVENT_LISTENER(cnc_dotasks, graphic_display_update);
+	ADD_EVENT_LISTENER(cnc_io_dotasks, graphic_display_rotary_encoder_control_sample);
 #else
 #warning "Main loop extensions are not enabled. Graphic display card will not work."
 #endif
@@ -777,10 +777,7 @@ void system_menu_render_idle(void)
 	y -= (FONTHEIGHT + 3);
 #endif
 
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 #if (AXIS_COUNT >= 3)
 	buff[0] = 'Z';
@@ -798,7 +795,8 @@ void system_menu_render_idle(void)
 	y -= (FONTHEIGHT + 3);
 #endif
 
-	if (!cnc_get_exec_state(EXEC_ALARM))
+	cnc_dotasks();
+
 	{
 		cnc_dotasks();
 	}
@@ -817,10 +815,7 @@ void system_menu_render_idle(void)
 	y -= (FONTHEIGHT + 3);
 #endif
 
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 	// units, feed and tool
 	if (g_settings.report_inches)
@@ -856,10 +851,7 @@ void system_menu_render_idle(void)
 
 	y -= (FONTHEIGHT + 3);
 
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 	// system status
 	rom_strcpy(buff, __romstr__("St:"));
@@ -913,10 +905,7 @@ void system_menu_render_idle(void)
 	io_states_str(buff);
 	u8g2_DrawStr(U8G2, (LCDWIDTH >> 1), y, buff);
 
-	if (!cnc_get_exec_state(EXEC_ALARM))
-	{
-		cnc_dotasks();
-	}
+	cnc_dotasks();
 
 	u8g2_SendBuffer(U8G2);
 }
@@ -949,10 +938,8 @@ void system_menu_item_render_label(uint8_t render_flags, const char *label)
 	uint8_t y = y_coord;
 	if (label)
 	{
-		if (!cnc_get_exec_state(EXEC_ALARM))
-		{
-			cnc_dotasks();
-		}
+		cnc_dotasks();
+
 		if (render_flags & SYSTEM_MENU_MODE_EDIT)
 		{
 			y_coord += FONTHEIGHT + 1;
@@ -976,10 +963,7 @@ void system_menu_item_render_arg(uint8_t render_flags, const char *value)
 {
 	if (value)
 	{
-		if (!cnc_get_exec_state(EXEC_ALARM))
-		{
-			cnc_dotasks();
-		}
+		cnc_dotasks();
 
 		uint8_t y = y_coord;
 

--- a/sd_card_pf/sd_card_pf.c
+++ b/sd_card_pf/sd_card_pf.c
@@ -38,7 +38,7 @@
 #define SD_FAT_FS PETIT_FAT_FS
 #endif
 
-#if (UCNC_MODULE_VERSION != 10800)
+#if (UCNC_MODULE_VERSION < 10800 || UCNC_MODULE_VERSION > 99999)
 #error "This module is not compatible with the current version of µCNC"
 #endif
 


### PR DESCRIPTION
- modified graphic display event hooks used to prevent loop inception that caused some menus to become irresponsive
- modified modules version check bounds