### PR TITLE
Grblhal keypad

### DIFF
--- a/grblhal_keypad/CHANGELOG.md
+++ b/grblhal_keypad/CHANGELOG.md
@@ -4,6 +4,6 @@ This module adds GrblHAL keypad to µCNC.
 
 ## Changelog
 
-### 2024-01-18
+### 2024-01-23
 
-- initial implementation (#40)
+- initial implementation

--- a/grblhal_keypad/CHANGELOG.md
+++ b/grblhal_keypad/CHANGELOG.md
@@ -1,0 +1,9 @@
+# About GrblHAL keypad for µCNC
+
+This module adds GrblHAL keypad to µCNC.
+
+## Changelog
+
+### 2024-01-18
+
+- initial implementation (#40)

--- a/grblhal_keypad/README.md
+++ b/grblhal_keypad/README.md
@@ -1,0 +1,20 @@
+# uCNC-modules
+
+Addon modules for µCNC - Universal CNC firmware for microcontrollers
+
+## About web pendant for µCNC
+
+This module adds GrblHAL keypad to µCNC.
+
+## Adding GrblHAL keypad to µCNC
+
+To use the GrblHAL keypad module follow these steps:
+
+1. Copy the the `grblhal_keypad` directory and place it inside the `src/modules/` directory of µCNC
+2. Then you need load the module inside µCNC. Open `src/module.c` and at the bottom of the file add the following lines inside the function `load_modules()`
+
+```
+LOAD_MODULE(grblhal_keypad);
+```
+
+3. The last step is to enable `ENABLE_IO_MODULES` and `ENABLE_MAIN_LOOP_MODULES` inside `cnc_config.h`

--- a/grblhal_keypad/README.md
+++ b/grblhal_keypad/README.md
@@ -13,8 +13,53 @@ To use the GrblHAL keypad module follow these steps:
 1. Copy the the `grblhal_keypad` directory and place it inside the `src/modules/` directory of µCNC
 2. Then you need load the module inside µCNC. Open `src/module.c` and at the bottom of the file add the following lines inside the function `load_modules()`
 
+3. You must configure the necessary interface (HW/SW I2C/UART) and pins that connect to the keypad in `cnc_hal_overrides.h`
+These are the default values
+
+Example using HW I2C
+```
+// to use hardware I2C define the interface
+#define KEYPAD_PORT KEYPAD_PORT_HW_I2C
+//define the strobe pin and interrupt mask
+#define KEYPAD_DOWN DIN7
+#define KEYPAD_DOWN_MASK DIN7_MASK //mask much match pin
+```
+
+Example using SW I2C
+```
+// to use software I2C define the interface
+#define KEYPAD_PORT KEYPAD_PORT_SW_I2C
+// define the strobe pin and interrupt mask
+// must be an interruptable pin
+#define KEYPAD_DOWN DIN7
+#define KEYPAD_DOWN_MASK DIN7_MASK //mask much match pin
+
+//define the pins used to bit-bang I2C
+#define KEYPAD_SCL DIN16
+#define KEYPAD_SDA DIN17
+```
+
+Example using HW UART2
+```
+// to use hardware UART2 define the interface
+#define KEYPAD_PORT KEYPAD_PORT_HW_UART2
+// you need to detach UART2 from the main protocol to be able to use it for this case
+#define DETACH_UART2_FROM_MAIN_PROTOCOL
+```
+
+Example using SW UART
+```
+// to use software UART define the interface
+#define KEYPAD_PORT KEYPAD_PORT_SW_UART
+// define the pins used to bit-bang UART
+// RX pin must be interrupt capable to detect incomming keypad requests
+#define KEYPAD_RX DIN7
+#define KEYPAD_RX_MASK DIN7_MASK //mask much match pin
+#define KEYPAD_TX DOUT20
+```
+
 ```
 LOAD_MODULE(grblhal_keypad);
 ```
 
-3. The last step is to enable `ENABLE_IO_MODULES` and `ENABLE_MAIN_LOOP_MODULES` inside `cnc_config.h`
+4. The last step is to enable `ENABLE_IO_MODULES` and `ENABLE_MAIN_LOOP_MODULES` inside `cnc_config.h`

--- a/grblhal_keypad/README.md
+++ b/grblhal_keypad/README.md
@@ -58,6 +58,11 @@ Example using SW UART
 #define KEYPAD_TX DOUT20
 ```
 
+You can also enable MPG mode by adding
+```
+#define KEYPAD_MPG_MODE_ENABLED
+```
+
 ```
 LOAD_MODULE(grblhal_keypad);
 ```

--- a/grblhal_keypad/grblhal_keypad.c
+++ b/grblhal_keypad/grblhal_keypad.c
@@ -453,8 +453,30 @@ MCU_RX_CALLBACK void mcu_uart2_rx_cb(uint8_t c)
 }
 #endif
 
+#ifdef KEYPAD_MPG_MODE_ENABLED
+bool grblhal_keypad_send_status(void *args)
+{
+	protocol_send_string(__romstr__("MPG:"));
+	
+	if (keypad_has_control)
+	{
+		serial_putc('1');
+	}
+	else{
+		serial_putc('0');
+	}
+
+	return EVENT_CONTINUE;
+}
+CREATE_EVENT_LISTENER(protocol_send_status, grblhal_keypad_send_status);
+#endif
+
 DECL_MODULE(grblhal_keypad)
 {
+#ifdef KEYPAD_MPG_MODE_ENABLED
+	ADD_EVENT_LISTENER(protocol_send_status, grblhal_keypad_send_status);
+#endif
+
 #ifdef ENABLE_SETTINGS_MODULES
 	EXTENDED_SETTING_INIT(KEYPAD_SETTING_ID, keypad_settings);
 #endif

--- a/grblhal_keypad/grblhal_keypad.c
+++ b/grblhal_keypad/grblhal_keypad.c
@@ -1,0 +1,209 @@
+/*
+	Name: grblhal_keypad.c
+	Description: Implements GrblHAL keypad for µCNC.
+
+	Copyright: Copyright (c) João Martins
+	Author: João Martins
+	Date: 18-01-2024
+
+	µCNC is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version. Please see <http://www.gnu.org/licenses/>
+
+	µCNC is distributed WITHOUT ANY WARRANTY;
+	Also without the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the	GNU General Public License for more details.
+*/
+
+#include "../../cnc.h"
+#include "../softi2c.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifndef KEYPAD_PORT
+// use 1 for HW I2C and 2 for HW UART
+// use 3 for SW I2C and 4 for SW UART
+#define KEYPAD_PORT 3
+#endif
+
+#ifndef KEYPAD_BUFFER_SIZE
+#define KEYPAD_BUFFER_SIZE 16
+#endif
+
+// I2C
+#if (KEYPAD_PORT & 1)
+// interruptable pins
+
+// halt pin is optional
+// #ifndef KEYPAD_HALT
+// #define KEYPAD_HALT DIN6
+// #endif
+#ifndef KEYPAD_DOWN
+#define KEYPAD_DOWN DIN7
+#define KEYPAD_DOWN_MASK DIN7_MASK
+#endif
+static softi2c_port_t *keypad_port;
+// use emulated I2C
+#if (KEYPAD_PORT & 2)
+#ifndef KEYPAD_SCL
+#define KEYPAD_SCL DIN16
+#endif
+#ifndef KEYPAD_SDA
+#define KEYPAD_SDA DIN17
+#endif
+#if !ASSERT_PIN(KEYPAD_SCL) || !ASSERT_PIN(KEYPAD_SDA)
+#error "The pins are not defined for this board"
+#else
+SOFTI2C(keypad_i2c, 400000, KEYPAD_SCL, KEYPAD_SDA);
+#endif
+#elif !defined(MCU_HAS_I2C)
+#error "The board does not support HW I2C"
+#endif
+
+#endif
+
+#if (UCNC_MODULE_VERSION < 10801 || UCNC_MODULE_VERSION > 99999)
+#error "This module is not compatible with the current version of µCNC"
+#endif
+
+DECL_BUFFER(uint8_t, grblhal_keypad_stream, KEYPAD_BUFFER_SIZE);
+#ifdef ENABLE_MAIN_LOOP_MODULES
+bool grblhal_keypad_process(void *args)
+{
+	// just do whatever you need here
+	uint8_t c;
+
+	BUFFER_DEQUEUE(grblhal_keypad_stream, &c);
+	switch (calloc)
+	{
+	case 0:
+		break;
+	case '0':
+		break;
+	case '1':
+		break;
+	case '2':
+		break;
+	case 'h':
+		break;
+	case 'H':
+		break;
+	case 'R':
+		break;
+	case 'L':
+		break;
+	case 'F':
+		break;
+	case 'B':
+		break;
+	case 'U':
+		break;
+	case 'D':
+		break;
+	case 'r':
+		break;
+	case 'q':
+		break;
+	case 's':
+		break;
+	case 't':
+		break;
+	case 'w':
+		break;
+	case 'v':
+		break;
+	case 'u':
+		break;
+	case 'x':
+		break;
+	case 'I':
+		break;
+	case 'i':
+		break;
+	case 'j':
+		break;
+	case 'K':
+		break;
+	case 'k':
+		break;
+	case 'z':
+		break;
+	case 'C':
+		break;
+	case 'M':
+		break;
+	default:
+		break;
+	}
+
+	// you must return EVENT_CONTINUE to enable other tasks to run or return EVENT_HANDLED to terminate the event handling within this callback
+	return EVENT_CONTINUE;
+}
+
+CREATE_EVENT_LISTENER(cnc_dotasks, grblhal_keypad_process);
+
+#endif
+
+#if defined(ENABLE_IO_MODULES) && (KEYPAD_PORT & 1)
+MCU_CALLBACK bool grblhal_keypad_pressed(void *args)
+{
+
+	// uint8_t args[] = {inputs, diff};
+	if (diff & KEYPAD_DOWN_MASK)
+	{
+		if (inputs & KEYPAD_DOWN_MASK)
+		{
+			// button released
+			cnc_call_rt_command(CMD_CODE_JOG_CANCEL);
+		}
+		else
+		{
+			// get the char and passes the char to the realtime char handler
+			uint8_t c = 0;
+			softi2c_receive(keypad_port, 0x49, &c, 1, 1);
+			// if not handled enqueues the char for processing
+			if (mcu_com_rx_cb(c))
+			{
+				// it's not an extended command
+				// do something
+			}
+		}
+	}
+	return EVENT_CONTINUE;
+}
+
+CREATE_EVENT_LISTENER(input_change, grblhal_keypad_pressed);
+#endif
+
+DECL_MODULE(grblhal_keypad)
+{
+#if (KEYPAD_PORT & 1)
+#if (KEYPAD_PORT & 2)
+	keypad_port = &keypad_i2c;
+#else
+	keypad_port = NULL;
+#endif
+#else
+#if (KEYPAD_PORT & 2)
+	keypad_port = &keypad_uart;
+#else
+	keypad_port = NULL;
+#endif
+#endif
+
+#ifdef ENABLE_MAIN_LOOP_MODULES
+	ADD_EVENT_LISTENER(cnc_dotasks, grblhal_keypad_process);
+#else
+	// just a warning in case you disabled the MAIN_LOOP option on build
+#warning "Main loop extensions are not enabled. Your module will not work."
+#endif
+
+#if defined(ENABLE_IO_MODULES) && (KEYPAD_PORT & 1)
+	ADD_EVENT_LISTENER(input_change, grblhal_keypad_pressed);
+#else
+#warning "IO extensions are not enabled. Your module will not work."
+#endif
+}

--- a/grblhal_keypad/grblhal_keypad.c
+++ b/grblhal_keypad/grblhal_keypad.c
@@ -183,7 +183,7 @@ DECL_EXTENDED_SETTING(KEYPAD_SETTING_ID, &keypad_settings, float, 6, protocol_se
 #endif
 
 #ifdef ENABLE_MAIN_LOOP_MODULES
-void __attribute__((weak)) keypad_extended_code(uint8_t &c){};
+void __attribute__((weak)) keypad_extended_code(uint8_t *c){}
 
 bool keypad_process(void *args)
 {


### PR DESCRIPTION
- Adds support for hardware based on GrblHAL [keypad protocol definition](https://github.com/grblHAL/core/wiki/MPG-and-DRO-interfaces#keypad-plugin).
- extends the support to software emulated ports (but probably with speed limitations)