### PR TITLE
fix ONEWIRE for TMC

### DIFF
--- a/tmc_driver/CHANGELOG.md
+++ b/tmc_driver/CHANGELOG.md
@@ -7,6 +7,10 @@ They can be interfaced either via UART or SPI (all software emulated)
 
 ### 2024-11-15
 
+- fix one wire transmission (replaced input weak pullup by output driven in output communication) (#86)
+
+### 2024-11-15
+
 - replace all TMC registers struct enums and bit fields by bit shifting operations since GCC does not garantee bit field order during optimization (#85)
 - added defaults to write only shadow registers (#85)
 

--- a/tmc_driver/tmc_driver.c
+++ b/tmc_driver/tmc_driver.c
@@ -79,12 +79,13 @@
 		stepper##CHANNEL##_select();                                                                      \
 		__ATOMIC__                                                                                        \
 		{                                                                                                 \
-			io_config_input(STEPPER##CHANNEL##_UART_RX);                                                    \
-			io_config_pullup(STEPPER##CHANNEL##_UART_RX);                                                   \
+			io_config_output(STEPPER##CHANNEL##_UART_RX);                                                   \
+			io_set_output(STEPPER##CHANNEL##_UART_RX);                                                      \
 			for (uint8_t i = 0; i < wlen; i++)                                                              \
 			{                                                                                               \
 				softuart_putc(&tmc##CHANNEL##_uart, data[i]);                                                 \
 			}                                                                                               \
+			io_config_input(STEPPER##CHANNEL##_UART_RX);                                                    \
 			for (uint8_t i = 0; i < rlen; i++)                                                              \
 			{                                                                                               \
 				data[i] = softuart_getc(&tmc##CHANNEL##_uart, TMC_UART_TIMEOUT(STEPPER##CHANNEL##_BAUDRATE)); \


### PR DESCRIPTION
- fix one wire transmission (replaced input weak pullup by output driven in output communication)